### PR TITLE
INSERT文に対応

### DIFF
--- a/src/fizzbuzz/ha_fizzbuzz.cc
+++ b/src/fizzbuzz/ha_fizzbuzz.cc
@@ -287,6 +287,17 @@ int ha_fizzbuzz::write_row(uchar *) {
     probably need to do something with 'buf'. We report a success
     here, to pretend that the insert was successful.
   */
+
+  char attribute_buffer[1024];
+  String attribute(attribute_buffer, sizeof(attribute_buffer), &my_charset_bin);
+
+  buffer.length(0);
+  for (Field **field = table->field; *field; field++) {
+    // 値を受け取る
+    (*field)->val_str(&attribute, &attribute);
+    buffer.append(attribute);
+  }
+  stats.records++;
   DBUG_RETURN(0);
 }
 

--- a/src/fizzbuzz/ha_fizzbuzz.cc
+++ b/src/fizzbuzz/ha_fizzbuzz.cc
@@ -251,6 +251,21 @@ int ha_fizzbuzz::close(void) {
   DBUG_RETURN(0);
 }
 
+std::string fizzbuzz(int now) {
+  if (now == 0) {
+    return std::to_string(now);
+  }
+  if (now % 3 == 0 && now % 5 == 0) {
+    return "fizzbuzz";
+  } else if (now % 3 == 0) {
+    return "fizz";
+  } else if (now % 5 == 0) {
+    return "buzz";
+  } else {
+    return std::to_string(now);
+  }
+}
+
 /**
   @brief
   write_row() inserts a row. No extra() hint is given currently if a bulk load
@@ -291,12 +306,9 @@ int ha_fizzbuzz::write_row(uchar *) {
   */
 
   for (Field **field = table->field; *field; field++) {
-    char attribute_buffer[1024];
-    String attribute(attribute_buffer, sizeof(attribute_buffer), &my_charset_bin);
     // 値を受け取る
-    (*field)->val_str(&attribute, &attribute);
-    std::string s(attribute.ptr(), attribute.ptr() + attribute.length());
-    stored_records.push_back(s);
+    std::string val = fizzbuzz(stats.records);
+    stored_records.push_back(val);
   }
   stats.records++;
   DBUG_RETURN(0);

--- a/src/fizzbuzz/ha_fizzbuzz.h
+++ b/src/fizzbuzz/ha_fizzbuzz.h
@@ -69,6 +69,7 @@ class ha_fizzbuzz : public handler {
   String buffer;
   int now_pos;
   bool stop;
+  std::vector<std::string> stored_records;
 
  public:
   ha_fizzbuzz(handlerton *hton, TABLE_SHARE *table_arg);

--- a/src/fizzbuzz/ha_fizzbuzz.h
+++ b/src/fizzbuzz/ha_fizzbuzz.h
@@ -102,7 +102,7 @@ class ha_fizzbuzz : public handler {
       an engine that can only handle statement-based logging. This is
       used in testing.
     */
-    return HA_BINLOG_STMT_CAPABLE;
+    return HA_BINLOG_STMT_CAPABLE | HA_BINLOG_ROW_CAPABLE;
   }
 
   /** @brief


### PR DESCRIPTION
Close #3 

`INSERT` に対応させるように改造した。

挙動としては次のような動きをする。

```
mysql> CREATE TABLE fizzbuzz.test (pos text) ENGINE=fizzbuzz;
Query OK, 0 rows affected (0.01 sec)

mysql> SELECT * FROM fizzbuzz.test;
Empty set (0.00 sec)

mysql> INSERT INTO fizzbuzz.test VALUES ("hoge");
Query OK, 1 row affected (0.00 sec)
mysql> SELECT * FROM fizzbuzz.test;
+------+
| pos  |
+------+
| 0    |
+------+
1 row in set (0.00 sec)

mysql> INSERT INTO fizzbuzz.test VALUES ("hoge");
Query OK, 1 row affected (0.01 sec)

mysql> INSERT INTO fizzbuzz.test VALUES ("hoge");
Query OK, 1 row affected (0.00 sec)

mysql> INSERT INTO fizzbuzz.test VALUES ("hoge");
Query OK, 1 row affected (0.01 sec)

mysql> SELECT * FROM fizzbuzz.test;
+------+
| pos  |
+------+
| 0    |
| 1    |
| 2    |
| fizz |
+------+
4 rows in set (0.00 sec)

...

mysql> SELECT * FROM fizzbuzz.test;
+----------+
| pos      |
+----------+
| 0        |
| 1        |
| 2        |
| fizz     |
| 4        |
| buzz     |
| fizz     |
| 7        |
| 8        |
| fizz     |
| buzz     |
| 11       |
| fizz     |
| 13       |
| 14       |
| fizzbuzz |
+----------+
16 rows in set (0.00 sec)
```

こんな感じ。どんな値も全部受け付けず (ひどい) fizzbuzz の演算をした結果を放り込むようにしている。
