### PR TITLE
UPDATE文の追加

### DIFF
--- a/src/fizzbuzz/ha_fizzbuzz.cc
+++ b/src/fizzbuzz/ha_fizzbuzz.cc
@@ -308,6 +308,9 @@ int ha_fizzbuzz::write_row(uchar *) {
   buffer.length(0);
   std::string val = fizzbuzz(stats.records);
   for (Field **field = table->field; *field; field++) {
+    for (const char &c : val) {
+      buffer.append(c);
+    }
     buffer.append('\0');
   }
   stored_records.push_back(val);

--- a/src/fizzbuzz/ha_fizzbuzz.cc
+++ b/src/fizzbuzz/ha_fizzbuzz.cc
@@ -307,6 +307,9 @@ int ha_fizzbuzz::write_row(uchar *) {
 
   buffer.length(0);
   std::string val = fizzbuzz(stats.records);
+  for (Field **field = table->field; *field; field++) {
+    buffer.append('\0');
+  }
   stored_records.push_back(val);
 
   stats.records++;
@@ -338,7 +341,24 @@ int ha_fizzbuzz::write_row(uchar *) {
 */
 int ha_fizzbuzz::update_row(const uchar *, uchar *) {
   DBUG_ENTER("ha_fizzbuzz::update_row");
-  DBUG_RETURN(HA_ERR_WRONG_COMMAND);
+  int rc = 0;
+
+  buffer.length(0);
+  for (Field **field = table->field; *field; field++) {
+    char attribute_buffer[1024];
+    String attribute(attribute_buffer, sizeof(attribute_buffer), &my_charset_bin);
+
+    // Get value from field
+    (*field)->val_str(&attribute, &attribute);
+    buffer.append(attribute);
+    buffer.append('\0');
+  }
+
+  std::string s(buffer.ptr(), buffer.ptr() + buffer.length());
+  // update
+  stored_records[stats.records-1] = s;
+
+  DBUG_RETURN(rc);
 }
 
 /**
@@ -482,6 +502,7 @@ int ha_fizzbuzz::rnd_end() {
   sql_update.cc
 */
 int ha_fizzbuzz::rnd_next(uchar *buf) {
+  int offset = 0;
   int rc;
   DBUG_ENTER("ha_fizzbuzz::rnd_next");
   // bufを0埋めする
@@ -489,12 +510,15 @@ int ha_fizzbuzz::rnd_next(uchar *buf) {
 
   if (stats.records < stored_records.size()) {
     // フィールドごとに演算の対応を行う
+    const auto &record = stored_records[stats.records];
     for (Field **field = table->field; *field; field++) {
       buffer.length(0);
-      for (auto c : stored_records[stats.records]) {
-        buffer.append(c);
+
+      for (int i = 0; i < (int)record.length() && record[offset+i]; i++) {
+        buffer.append(record[offset+i]);
       }
       (*field)->store(buffer.ptr(), buffer.length(), buffer.charset(), CHECK_FIELD_IGNORE);
+      offset += buffer.length();
     }
     rc = 0;
     stats.records++;


### PR DESCRIPTION
UPDATEできるようにする。

Resolves: #6 #7 

```sql
mysql> SELECT * FROM fizzbuzz.test;
+----------+-------+
| id       | value |
+----------+-------+
| 0        |       |
| 1        |       |
| 2        |       |
| fizz     |       |
| 4        |       |
| buzz     |       |
| fizz     |       |
| 7        |       |
| 8        |       |
| fizz     |       |
| buzz     |       |
| 11       |       |
| fizz     |       |
| 13       |       |
| 14       |       |
| fizzbuzz |       |
| 16       |       |
| 17       |       |
| fizz     |       |
| 19       |       |
| buzz     |       |
| fizz     |       |
| 22       |       |
| 23       |       |
| fizz     |       |
| buzz     |       |
| 26       |       |
| fizz     |       |
| 28       |       |
| 29       |       |
| fizzbuzz |       |
| 31       |       |
+----------+-------+
32 rows in set (0.00 sec)

mysql> SHOW CREATE TABLE fizzbuzz.test;
+-------+------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                           |
+-------+------------------------------------------------------------------------------------------------------------------------+
| test  | CREATE TABLE `test` (
  `id` text,
  `value` text
) ENGINE=FIZZBUZZ DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci |
+-------+------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

mysql> UPDATE fizzbuzz.test SET id='fizzbuzz' WHERE id='fizz';
Query OK, 8 rows affected (0.01 sec)
Rows matched: 8  Changed: 8  Warnings: 0

mysql> SELECT * FROM fizzbuzz.test;
+----------+-------+
| id       | value |
+----------+-------+
| 0        |       |
| 1        |       |
| 2        |       |
| fizzbuzz |       |
| 4        |       |
| buzz     |       |
| fizzbuzz |       |
| 7        |       |
| 8        |       |
| fizzbuzz |       |
| buzz     |       |
| 11       |       |
| fizzbuzz |       |
| 13       |       |
| 14       |       |
| fizzbuzz |       |
| 16       |       |
| 17       |       |
| fizzbuzz |       |
| 19       |       |
| buzz     |       |
| fizzbuzz |       |
| 22       |       |
| 23       |       |
| fizzbuzz |       |
| buzz     |       |
| 26       |       |
| fizzbuzz |       |
| 28       |       |
| 29       |       |
| fizzbuzz |       |
| 31       |       |
+----------+-------+
32 rows in set (0.00 sec)
```

🆗 