### PR TITLE
support DELETE statement

### DIFF
--- a/src/fizzbuzz/ha_fizzbuzz.cc
+++ b/src/fizzbuzz/ha_fizzbuzz.cc
@@ -385,8 +385,13 @@ int ha_fizzbuzz::update_row(const uchar *, uchar *) {
 */
 
 int ha_fizzbuzz::delete_row(const uchar *) {
+  int rc = 0;
   DBUG_ENTER("ha_fizzbuzz::delete_row");
-  DBUG_RETURN(HA_ERR_WRONG_COMMAND);
+
+  stored_records.erase(stored_records.begin()+stats.records-1);
+  stats.records--;
+
+  DBUG_RETURN(rc);
 }
 
 /**


### PR DESCRIPTION
```sql
mysql> SELECT * FROM fizzbuzz.test;
+------+-------+
| id   | value |
+------+-------+
| 0    |       |
| 1    |       |
| 2    |       |
| fizz |       |
| 4    |       |
| buzz |       |
| fizz |       |
| 7    |       |
| 8    |       |
+------+-------+
9 rows in set (0.00 sec)

mysql> DELETE FROM fizzbuzz.test WHERE id='fizz';
Query OK, 2 rows affected (0.00 sec)

mysql> SELECT * FROM fizzbuzz.test;
+------+-------+
| id   | value |
+------+-------+
| 0    |       |
| 1    |       |
| 2    |       |
| 4    |       |
| buzz |       |
| 7    |       |
| 8    |       |
+------+-------+
7 rows in set (0.00 sec)

mysql> DELETE FROM fizzbuzz.test WHERE value='';
Query OK, 7 rows affected (0.00 sec)

mysql> SELECT * FROM fizzbuzz.test;
Empty set (0.00 sec)
```

こんな感じできちんと動いた 